### PR TITLE
Inclusion request for my own gem repo

### DIFF
--- a/bcl_manifest.json
+++ b/bcl_manifest.json
@@ -14,5 +14,10 @@
     "org": "BuildingComponentLibrary",
     "type": "measure",
     "url": "https://github.com/BuildingComponentLibrary/legacy-NREL-measures-gem"
+  }, {
+    "name": "openstudio-effibem-measures-gem",
+    "org": "jmarrec",
+    "type": "measure",
+    "url": "https://github.com/jmarrec/openstudio-effibem-measures-gem"
   }]
 }


### PR DESCRIPTION
Added https://github.com/jmarrec/openstudio-effibem-measures-gem to manifest.json

It doesn't contain much yet, but I'm trying out the process, and have more things to migrate when I can carve out more time.

For now it has one measure that demonstrates how to create a ModelMeasure that acts like a ReportingMeasure except that you can "Apply Now" (without running the model)