### PR TITLE
Adding LBNL-BCL-Windows repo to bcl_manifest.json

### DIFF
--- a/bcl_manifest.json
+++ b/bcl_manifest.json
@@ -75,5 +75,10 @@
     "org": "Ski90Moo",
     "type": "measure",
     "url": "https://github.com/Ski90Moo/OpenStudio_Measures_HEPLLC"
+  },{
+    "name": "LBNL-BCL-Windows",
+    "org": "LBNL-ETA",
+    "type": "component",
+    "url": "https://github.com/LBNL-ETA/LBNL-BCL-Windows"
   }]
 }


### PR DESCRIPTION
LBNL would like to be able to add windows as components to the BCL via the LBNL-BCL-Windows repo.  Please let us know if you find anything wrong with it or have any suggestions.