### PR TITLE
Request to add PNNL Building Energy Standard Measure Repo to BCL Library

### DIFF
--- a/bcl_manifest.json
+++ b/bcl_manifest.json
@@ -80,5 +80,10 @@
     "org": "LBNL-ETA",
     "type": "component",
     "url": "https://github.com/LBNL-ETA/LBNL-BCL-Windows"
+  },{
+    "name": "OpenStudio Building Energy Standard Measures",
+    "org": "PNNL",
+    "type": "measure",
+    "url": "https://github.com/pnnl/openstudio-building-energy-standard-measures-gem"
   }]
 }


### PR DESCRIPTION
@kflemin 
Register PNNL Building Energy Standard Measure Repo with the BCL.
The PNNL Building Energy Standard Measure Repo is a comprehensive collection of innovative OpenStudio measures designed to facilitate energy code analysis. The measures in this repository expand and customize the OpenStudio framework to support diverse energy code related workflows. These workflows encompass, but are not limited to, exploratory design analysis on typical buildings, data acquisition for energy code compliance, and the streamlined automation of energy code modeling.