### PR TITLE
Add NIST Birds Nest Gem repository to bcl_manifest.json

### DIFF
--- a/bcl_manifest.json
+++ b/bcl_manifest.json
@@ -85,5 +85,10 @@
     "org": "PNNL",
     "type": "measure",
     "url": "https://github.com/pnnl/openstudio-building-energy-standard-measures-gem"
+  }, {
+    "name": "Openstudio NIST Birds Nest Measure",
+    "org": "NIST",
+    "type": "measure",
+    "url": "https://github.com/usnistgov/openstudio-birds-nest-gem"
   }]
 }


### PR DESCRIPTION
Request to add NIST Birds Nest measure to BCL.

The BIRDS NEST OpenStudio Measure communicates with NIST’s BIRDS NEST API to generate and report whole building life cycle assessment (wbLCA) results for residential buildings modeled in OpenStudio. The Measure combines automated input extraction from the OS model, E+ results, and user inputs required by the Measure (values not not defined or cannot currently be identified within the OS model) into an HPXML-based file structure that is sent to the BIRDS NEST API, which in turn sends back wbLCA results that are provided in a Results Report within OS.